### PR TITLE
Fix PVI asset role

### DIFF
--- a/bdc_collection_builder/celery/publish.py
+++ b/bdc_collection_builder/celery/publish.py
@@ -459,7 +459,19 @@ def publish_collection_item(scene_id: str, data: BaseCollection, collection: Col
 
                 asset_file_path = asset_file_path_tif
 
-            assets[asset_name] = _asset_definition(asset_file_path, is_raster=is_raster, cog=False, item_prefix=asset_item_prefix, prefix=prefix)
+            asset_definition_params = dict(
+                path=asset_file_path,
+                is_raster=is_raster,
+                cog=False,
+                item_prefix=asset_item_prefix,
+                prefix=prefix
+            )
+
+            if asset_name == 'PVI':
+
+                asset_definition_params.update(dict(role=['thumbnail']))
+
+            assets[asset_name] = _asset_definition(**asset_definition_params)
 
     index_bands = generate_band_indexes(scene_id, collection, file_band_map)
 

--- a/bdc_collection_builder/celery/publish.py
+++ b/bdc_collection_builder/celery/publish.py
@@ -110,7 +110,7 @@ def compress_raster(input_path: str, output_path: str, algorithm: str = 'deflate
         shutil.move(tmp_file, output_path)
 
 
-def _asset_definition(path, band=None, is_raster=False, cog=False, **options):
+def _asset_definition(path, band=None, is_raster=False, cog=False, role=['data'], **options):
     href = _item_prefix(path, **options)
 
     if band and band.mime_type:
@@ -122,7 +122,7 @@ def _asset_definition(path, band=None, is_raster=False, cog=False, **options):
         file=str(path),
         href=href,
         mime_type=mime_type,
-        role=['data'],
+        role=role,
         is_raster=is_raster
     )
 


### PR DESCRIPTION
Problema: O valor da propriedade _roles_ do asset PVI estava sendo gerado com o valor _data_, quando deveria ser _thumbnail_.

Correção:
- o valor da propriedade _role_ foi incluído como parâmetro da função _asset_definition(), sendo definido como _data_ por padrão.
- Adicionado condicional para permitir que a propriedade role seja alterada para _thumbnail_ quando for o asset PVI.